### PR TITLE
Hotfixes for splitting

### DIFF
--- a/casino/blackjack.py
+++ b/casino/blackjack.py
@@ -227,7 +227,7 @@ class Game:
             if p.players[uid].hand.hand_value() == 21:
                 self.phenny.say("Blackjack! %s reached 21, therefore they stand." % p.players[uid].name)
                 self.stand(pid)
-            elif len(self.turns) > 0 and self.is_current_player(pid): # This players next move
+            elif len(self.turns) > 0 and self.turns[0] == uid: # This players next move
                 self.accept_surrender  = False
                 self.accept_doubledown = False
                 self.accept_split      = False

--- a/casino/blackjack.py
+++ b/casino/blackjack.py
@@ -344,7 +344,7 @@ class Game:
             self.accept_doubledown = False
 
     def set_split(self,uid):
-        if p.players[uid].hand.cards[0].rank == p.players[uid].hand.cards[1].rank and p.players[uid].gold >= int(p.players[uid].bet):
+        if p.players[uid].hand.cards[0].rank == p.players[uid].hand.cards[1].rank and p.players[uid].gold >= int(p.players[uid].bet) and p.players[uid].splits < 4:
             self.accept_split = True
         else:
             self.accept_split = False

--- a/results.txt
+++ b/results.txt
@@ -40,3 +40,20 @@ Hand as split player
 /NOTICE squessh Your Hand: 4H 5H AH 
 /NOTICE squessh Your Hand: 4S 5D 
 /NOTICE squessh Your Hand: 4C 10S  <- Current Hand
+------------------------------------------
+Player 2 splits
+------------------------------------------
+Split. veesh has split his hand to two, adding his bet of 100 to his second hand
+Hit. veesh: 10H 3C 
+Hit. veesh: 10S 4H 
+/NOTICE veesh Your Hand: 10H 3C  <- Current Hand
+/NOTICE veesh Your Hand: 10S 4H 
+veesh. !Stand, !Hit, or !Surrender?
+------------------------------------------
+Player 2 loses
+------------------------------------------
+Hit. veesh: 10H 3C 10H 
+/NOTICE veesh You lost your bet of 100 gold. You have 300 left.
+BUST! veesh went over 21. Their bet was lost to the dealer.
+/NOTICE veesh Your Hand: 10S 4H 
+veesh. !Stand, !Hit, or !Surrender?

--- a/test.py
+++ b/test.py
@@ -114,7 +114,7 @@ for i in players:
 
 ##########################################
 # Actual Testing!
-deck = setup_deck("AS,7H,AC,AS,10H,10S,4H,4S,4C,5D,5H,10S,AH")
+deck = setup_deck("AS,7H,AC,AS,10H,10S,4H,4S,4C,5D,5H,10S,AH,3C,4H,10H")
 
 sner = make_game(guy.uid, guy.name)
 for i in players:
@@ -142,3 +142,11 @@ with test_banner("DoubleDown after Split"):
 
 with test_banner("Hand as split player"):
     sner.hand(players[2].uid)
+
+sner.stand(players[2].uid)
+sner.stand(players[2].uid)
+with test_banner("Player 2 splits"):
+    sner.split(players[1].uid)
+
+with test_banner("Player 2 loses"):
+    sner.hit(players[1].uid)


### PR DESCRIPTION
I fixed the issue with busting on a split hand (caused by not realizing the levels of the if statements. My bad). In addition, I capped splitting at four hands in the interest of not being able to overdraw during a game (however unlikely it is). If the latter is unwanted, then you can reverse the final commit.